### PR TITLE
EVA-2354 — Perform multiple alignment rounds

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -157,7 +157,6 @@ process sortVCF {
 
     """
     bgzip variants_remapped.vcf
-    tabix variants_remapped.vcf.gz
     bcftools sort -o variants_remapped_sorted.vcf.gz -Oz variants_remapped.vcf.gz
     """
 }
@@ -221,12 +220,13 @@ workflow finalise {
     take:
         variants_remapped
         vcf_header
+        genome
 
     main:
         buildHeader(variants_remapped, vcf_header)
         mergeHeaderAndContent(buildHeader.out.final_header, variants_remapped)
         sortVCF(mergeHeaderAndContent.out.final_vcf_with_header)
-        normalise(sortVCF.out.variants_remapped_sorted_gz, params.newgenome)
+        normalise(sortVCF.out.variants_remapped_sorted_gz, genome)
         calculateStats(normalise.out.final_output_vcf)
 }
 
@@ -256,7 +256,7 @@ workflow {
             prepare_new_genome.out.genome_fai
         )
         combineVCF(process_split_reads.out.variants_remapped, process_split_reads_mid.out.variants_remapped)
-        finalise(combineVCF.out.merge_vcf, storeVCFHeader.out.vcf_header)
+        finalise(combineVCF.out.merge_vcf, storeVCFHeader.out.vcf_header, params.newgenome)
 }
 
 //process_with_bowtie
@@ -275,5 +275,5 @@ workflow process_with_bowtie {
             prepare_new_genome_bowtie.out.genome_fai,
             prepare_new_genome_bowtie.out.bowtie_indexes
         )
-        finalise(process_split_reads_with_bowtie.out.variants_remapped, storeVCFHeader.out.vcf_header)
+        finalise(process_split_reads_with_bowtie.out.variants_remapped, storeVCFHeader.out.vcf_header, params.newgenome)
 }

--- a/main.nf
+++ b/main.nf
@@ -197,8 +197,6 @@ process combineVCF {
         path "variants1.vcf"
         path "variants2.vcf"
         path "variants3.vcf"
-
-
     output:
         path "merge.vcf", emit: merge_vcf
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pysam==0.15.4
 biopython==1.77
 pytest==6.2.2
+pyyaml==5.4

--- a/tests/test_pipeline.sh
+++ b/tests/test_pipeline.sh
@@ -26,7 +26,7 @@ nextflow run ${SOURCE_DIR}/main.nf \
 
 # Check the presence of the output file
 ls ${SCRIPT_DIR}/resources/remap.vcf \
-   ${SCRIPT_DIR}/resources/remap.vcf.stats
+   ${SCRIPT_DIR}/resources/remap.vcf.yml
 
 # Build the expected VCF
 cat << EOT > "${SCRIPT_DIR}/resources/expected_remap.vcf"

--- a/tests/test_pipeline.sh
+++ b/tests/test_pipeline.sh
@@ -37,6 +37,7 @@ chr2	98	.	C	CG	50	PASS	.
 chr2	1078	.	A	G	50	PASS	.
 chr2	1818	.	AAC	A	50	PASS	.
 chr2	2030	.	A	TCC	50	PASS	.
+chr2	3509	.	T	C	50	PASS	.
 EOT
 
 # Compare vs the expected VCF

--- a/tests/test_pipeline.sh
+++ b/tests/test_pipeline.sh
@@ -31,13 +31,13 @@ ls ${SCRIPT_DIR}/resources/remap.vcf \
 # Build the expected VCF
 cat << EOT > "${SCRIPT_DIR}/resources/expected_remap.vcf"
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
-chr2	48	.	C	A	50	PASS	.
-chr2	48	.	C	T	50	PASS	.
-chr2	98	.	C	CG	50	PASS	.
-chr2	1078	.	A	G	50	PASS	.
-chr2	1818	.	AAC	A	50	PASS	.
-chr2	2030	.	A	TCC	50	PASS	.
-chr2	3510	.	T	C	50	PASS	.
+chr2	48	.	C	A	50	PASS	st=+;rac=.
+chr2	48	.	C	T	50	PASS	st=+;rac=.
+chr2	98	.	C	CG	50	PASS	st=+;rac=.
+chr2	1078	.	A	G	50	PASS	st=+;rac=G-A
+chr2	1818	.	AAC	A	50	PASS	st=+;rac=.
+chr2	2030	.	A	TCC	50	PASS	st=+;rac=.
+chr2	3510	.	T	C	50	PASS	st=+;rac=.
 EOT
 
 # Compare vs the expected VCF

--- a/tests/test_pipeline.sh
+++ b/tests/test_pipeline.sh
@@ -37,7 +37,7 @@ chr2	98	.	C	CG	50	PASS	.
 chr2	1078	.	A	G	50	PASS	.
 chr2	1818	.	AAC	A	50	PASS	.
 chr2	2030	.	A	TCC	50	PASS	.
-chr2	3509	.	T	C	50	PASS	.
+chr2	3510	.	T	C	50	PASS	.
 EOT
 
 # Compare vs the expected VCF

--- a/variant_remapping_tools/reads_to_remapped_variants.py
+++ b/variant_remapping_tools/reads_to_remapped_variants.py
@@ -189,16 +189,16 @@ def link_supplementary(primary_group, supplementary_group):
     supplementary_dict = {}
     primary_to_supplementary = defaultdict(list)
     for supplementary_read in supplementary_group:
-        supplementary_dict[supplementary_read.reference_name + str(supplementary_read.reference_start)] = supplementary_read
+        supplementary_dict[supplementary_read.reference_name + str(supplementary_read.reference_start + 1)] = supplementary_read
     for primary in primary_group:
         # chr2,808117,+,1211M790S,60,1;
-        if primary.has_tag():
-            other_alignments = primary.get_tag('AS').split(';')
-            for other_alignment in other_alignments:
-                rname, pos = other_alignment.split(',')[:2]
-                primary_to_supplementary[primary].append(
-                    supplementary_dict[rname + pos]
-                )
+        if primary.has_tag('SA'):
+            for other_alignment in primary.get_tag('SA').split(';'):
+                if other_alignment:
+                    rname, pos = other_alignment.split(',')[:2]
+                    primary_to_supplementary[primary].append(
+                        supplementary_dict[rname + pos]
+                    )
     return dict(primary_to_supplementary)
 
 

--- a/variant_remapping_tools/reads_to_remapped_variants.py
+++ b/variant_remapping_tools/reads_to_remapped_variants.py
@@ -107,7 +107,8 @@ def group_reads(bam_file_path):
             else:
                 primary_group.append(read)
             current_read_name = read.query_name
-        yield primary_group, supplementary_group, secondary_group
+        if primary_group:
+            yield primary_group, supplementary_group, secondary_group
 
 
 def _order_reads(group):
@@ -179,9 +180,6 @@ def process_bam_file(bam_file_path, output_file, out_failed_file, new_genome, fi
                     output_failed_alignment(primary_group, out_failed)
             else:
                 output_failed_alignment(primary_group, out_failed)
-    for metric in counter.keys() - {'total'}:
-        print(f'{counter[metric]} ({counter[metric]/counter["total"]:.2%}) variants rejected for {metric}')
-
     with open(summary_file, 'w') as open_summary:
         yaml.safe_dump({f'Flank_{flank_length}': dict(counter)}, open_summary)
 

--- a/variant_remapping_tools/reads_to_remapped_variants.py
+++ b/variant_remapping_tools/reads_to_remapped_variants.py
@@ -7,6 +7,7 @@ import yaml
 from Bio.Seq import Seq
 from Bio.Alphabet import generic_dna
 import pysam
+from pysam.libcvcf import defaultdict
 
 
 def reverse_complement(sequence):
@@ -24,40 +25,48 @@ def calculate_new_variant_definition(left_read, right_read, ref_fasta):
     old_ref = info[2]
     old_alts = info[3].split(',')
 
+    operations = []
     # Define new ref and new pos
     new_ref = fetch_bases(ref_fasta, left_read.reference_name, left_read.reference_end + 1,
                           right_read.reference_start - left_read.reference_end)
     new_pos = left_read.reference_end + 1
 
-    # TODO: All th operation bellow should be recorded so they can be used for subsequent changes of the genotypes.
+    # TODO: All the operation bellow should be recorded so they can be used for subsequent changes of the genotypes.
     # 1. Handle reference strand change
     if not left_read.is_reverse and not right_read.is_reverse:
         # Forward strand alignment
         old_ref_conv = old_ref
         old_alt_conv = old_alts
+        operations.append('st=+')
     elif left_read.is_reverse and right_read.is_reverse:
         # Reverse strand alignment
         old_ref_conv = reverse_complement(old_ref)
         old_alt_conv = [reverse_complement(alt) for alt in old_alts]
+        operations.append('st=-')
 
     # 2. Assign new allele sequences
     if new_ref == old_ref_conv:
         new_alts = old_alt_conv
+        operations.append('rac=.')
     elif new_ref in old_alt_conv:
         old_alt_conv.remove(new_ref)
         new_alts = old_alt_conv
         new_alts.append(old_ref_conv)
+        operations.append('rac=' + old_ref_conv + '-' + new_ref)
     else:
         new_alts = old_alt_conv
         new_alts.append(old_ref_conv)
+        operations.append('rac=' + old_ref_conv + '-' + new_ref)
+        operations.append('nra=T')
 
     # 3. Correct zero-length reference sequence
     if len(new_ref) == 0:
         new_pos -= 1
         new_ref = fetch_bases(ref_fasta, left_read.reference_name, new_pos, 1)
         new_alts = [new_ref + alt for alt in new_alts]
+        operations.append('zlr=T')
 
-    return new_pos, new_ref, new_alts
+    return new_pos, new_ref, new_alts, operations
 
 
 def fetch_bases(fasta, contig, start, length):
@@ -73,10 +82,10 @@ def fetch_bases(fasta, contig, start, length):
 def group_reads(bam_file_path):
     """
     This function assumes that the reads are sorted by query name.
-    It will group reads by query name and create two subgroups of primary and secondary aligned reads.
-    It returns an iterators where each element is a tuple of two lists
+    It will group reads by query name and create three subgroups of primary, supplementary and secondary aligned reads.
+    It returns an iterators where each element is a tuple of the three lists
     :param bam_file_path: the name sorted bam file
-    :return: iterator of tuples containing two lists
+    :return: iterator of tuples containing three lists
     """
     with pysam.AlignmentFile(bam_file_path, 'rb') as inbam:
         current_read_name = None
@@ -103,16 +112,32 @@ def group_reads(bam_file_path):
             yield primary_group, supplementary_group, secondary_group
 
 
-def _order_reads(group):
-    """Order read and return the most 5' (smallest coordinates) first."""
-    read1, read2 = group
+def _order_reads(primary_group, primary_to_supplementary):
+    """
+    Order read and return the most 5' (smallest coordinates) first.
+    if a supplementary read exists and is closer to the other read then it is used in place of the primary
+    """
+    read1, read2 = primary_group
+    suppl_read1 = suppl_read2 = None
+    if read1 in primary_to_supplementary:
+        suppl_read1 = primary_to_supplementary.get(read1)[0]
+    if read2 in primary_to_supplementary:
+        suppl_read2 = primary_to_supplementary.get(read2)[0]
     if read1.reference_start <= read2.reference_start:
+        if suppl_read1 and suppl_read1.reference_start > read1.reference_start:
+            read1 = suppl_read1
+        if suppl_read2 and suppl_read2.reference_start < read2.reference_start:
+            read2 = suppl_read2
         return read1, read2
     else:
+        if suppl_read1 and suppl_read1.reference_start < read1.reference_start:
+            read1 = suppl_read1
+        if suppl_read2 and suppl_read2.reference_start > read2.reference_start:
+            read2 = suppl_read2
         return read2, read1
 
 
-def pass_basic_filtering(primary_group, secondary_group, counter, filter_align_with_secondary):
+def pass_basic_filtering(primary_group, secondary_group, primary_to_supplementary, counter, filter_align_with_secondary):
     """Test if the alignment pass basic filtering such as presence of secondary alignments, any primary unmapped,
     primary mapped on different chromosome, or primary mapped poorly."""
     if filter_align_with_secondary and len(secondary_group):
@@ -121,6 +146,8 @@ def pass_basic_filtering(primary_group, secondary_group, counter, filter_align_w
         counter['Flank unmapped'] += 1
     elif len(set(read.reference_name for read in primary_group)) != 1:
         counter['Different chromosomes'] += 1
+    elif any(len(suppl) > 1 for suppl in primary_to_supplementary.values()):
+        counter['Too many supplementary'] += 1
     else:
         return True
     return False
@@ -154,6 +181,27 @@ def output_failed_alignment(primary_group, outfile):
     print('\t'.join(info[:2] + [info[4]] + info[2:4] + info[5:]), file=outfile)
 
 
+def link_supplementary(primary_group, supplementary_group):
+    """Link supplementary alignments to their primary."""
+    if not supplementary_group:
+        # No supplementary so no linking required
+        return {}
+    supplementary_dict = {}
+    primary_to_supplementary = defaultdict(list)
+    for supplementary_read in supplementary_group:
+        supplementary_dict[supplementary_read.reference_name + str(supplementary_read.reference_start)] = supplementary_read
+    for primary in primary_group:
+        # chr2,808117,+,1211M790S,60,1;
+        if primary.has_tag():
+            other_alignments = primary.get_tag('AS').split(';')
+            for other_alignment in other_alignments:
+                rname, pos = other_alignment.split(',')[:2]
+                primary_to_supplementary[primary].append(
+                    supplementary_dict[rname + pos]
+                )
+    return dict(primary_to_supplementary)
+
+
 def process_bam_file(bam_file_path, output_file, out_failed_file, new_genome, filter_align_with_secondary,
                      flank_length, summary_file):
     counter = Counter()
@@ -161,12 +209,17 @@ def process_bam_file(bam_file_path, output_file, out_failed_file, new_genome, fi
     with open(output_file, 'w') as outfile, open(out_failed_file, 'w') as out_failed:
         for primary_group, supplementary_group, secondary_group in group_reads(bam_file_path):
             counter['total'] += 1
-            if pass_basic_filtering(primary_group, secondary_group, counter, filter_align_with_secondary):
-                left_read, right_read = _order_reads(primary_group)
+            primary_to_supplementary = link_supplementary(primary_group, supplementary_group)
+            if pass_basic_filtering(primary_group, secondary_group, primary_to_supplementary, counter, filter_align_with_secondary):
+                left_read, right_read = _order_reads(primary_group, primary_to_supplementary)
                 if pass_aligned_filtering(left_read, right_read, counter):
                     counter['Remapped'] += 1
-                    varpos, new_ref, new_alts = calculate_new_variant_definition(left_read, right_read, fasta)
+                    varpos, new_ref, new_alts, ops= calculate_new_variant_definition(left_read, right_read, fasta)
                     info = left_read.query_name.split('|')
+                    if info[7] != '.':
+                        info[7] += ';'.join(ops)
+                    else:
+                        info[7] = ';'.join(ops)
                     outfile.write(
                         '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' % (left_read.reference_name, varpos, info[4], new_ref,
                                                               ','.join(new_alts), info[5], info[6], info[7]))

--- a/variant_remapping_tools/reads_to_remapped_variants.py
+++ b/variant_remapping_tools/reads_to_remapped_variants.py
@@ -1,13 +1,12 @@
 #! /usr/bin/env python3
 import argparse
 from argparse import RawTextHelpFormatter
-from collections import Counter
+from collections import Counter, defaultdict
 
 import yaml
 from Bio.Seq import Seq
 from Bio.Alphabet import generic_dna
 import pysam
-from pysam.libcvcf import defaultdict
 
 
 def reverse_complement(sequence):
@@ -214,7 +213,7 @@ def process_bam_file(bam_file_path, output_file, out_failed_file, new_genome, fi
                 left_read, right_read = _order_reads(primary_group, primary_to_supplementary)
                 if pass_aligned_filtering(left_read, right_read, counter):
                     counter['Remapped'] += 1
-                    varpos, new_ref, new_alts, ops= calculate_new_variant_definition(left_read, right_read, fasta)
+                    varpos, new_ref, new_alts, ops = calculate_new_variant_definition(left_read, right_read, fasta)
                     info = left_read.query_name.split('|')
                     if info[7] != '.':
                         info[7] += ';'.join(ops)

--- a/variant_remapping_tools/reads_to_remapped_variants.py
+++ b/variant_remapping_tools/reads_to_remapped_variants.py
@@ -30,7 +30,7 @@ def calculate_new_variant_definition(left_read, right_read, ref_fasta):
                           right_read.reference_start - left_read.reference_end)
     new_pos = left_read.reference_end + 1
 
-    # TODO: All the operation bellow should be recorded so they can be used for subsequent changes of the genotypes.
+    # TODO: apply the changes to the genotypes as well if they are present.
     # 1. Handle reference strand change
     if not left_read.is_reverse and not right_read.is_reverse:
         # Forward strand alignment

--- a/variant_remapping_tools/reads_to_remapped_variants.py
+++ b/variant_remapping_tools/reads_to_remapped_variants.py
@@ -120,10 +120,8 @@ def group_reads(bam_file_path):
 
 
 def _order_reads(primary_group, primary_to_supplementary):
-    """
-    Order read and return the most 5' (smallest coordinates) first.
-    if a supplementary read exists and is closer to the other read then it is used in place of the primary
-    """
+    """Order reads and return the most 5' (smallest coordinates) first.
+    If a supplementary read exists and is closer to the other read then it is used in place of the primary."""
     read1, read2 = primary_group
     suppl_read1 = suppl_read2 = None
     if read1 in primary_to_supplementary:
@@ -253,7 +251,7 @@ def main():
     parser.add_argument('--flank_length', type=int, required=True,
                         help='Length of the flanking region used.')
     parser.add_argument('--summary', type=str, required=True,
-                        help='Yaml files containing the summary metrics')
+                        help='YAML files containing the summary metrics')
 
     parser.add_argument('-f', '--filter_align_with_secondary', action='store_true', default=False,
                         help='Filter out alignments that have one or several secondary alignments.')

--- a/variant_remapping_tools/reads_to_remapped_variants.py
+++ b/variant_remapping_tools/reads_to_remapped_variants.py
@@ -42,6 +42,14 @@ def calculate_new_variant_definition(left_read, right_read, ref_fasta):
         old_ref_conv = reverse_complement(old_ref)
         old_alt_conv = [reverse_complement(alt) for alt in old_alts]
         operations.append('st=-')
+    else:
+        # This case should be handled by the filtering but raise just in case...
+        error_msg = (f'Impossible read configuration: '
+                     f'read1 is_reverse: {left_read.is_reverse}, '
+                     f'read2 is_reverse: {right_read.is_reverse}, '
+                     f'read1 position: {left_read.pos}, '
+                     f'read2 position: {right_read.pos}')
+        raise ValueError(error_msg)
 
     # 2. Assign new allele sequences
     if new_ref == old_ref_conv:

--- a/variant_remapping_tools/reads_to_remapped_variants.py
+++ b/variant_remapping_tools/reads_to_remapped_variants.py
@@ -39,14 +39,6 @@ def calculate_new_variant_definition(left_read, right_read, ref_fasta):
         # Reverse strand alignment
         old_ref_conv = reverse_complement(old_ref)
         old_alt_conv = [reverse_complement(alt) for alt in old_alts]
-    else:
-        error_msg = (f'Impossible read configuration: '
-                     f'read1 is_reverse: {left_read.is_reverse}, '
-                     f'read2 is_reverse: {right_read.is_reverse}, '
-                     f'read1 position: {left_read.reference_start}, '
-                     f'read2 position: {right_read.reference_start}')
-        print(error_msg)
-        raise ValueError(error_msg)
 
     # 2. Assign new allele sequences
     if new_ref == old_ref_conv:
@@ -147,6 +139,8 @@ def pass_aligned_filtering(left_read, right_read, counter):
         counter['Soft-clipped alignments'] += 1
     elif left_read.reference_end > right_read.reference_start:
         counter['Overlapping alignment'] += 1
+    elif left_read.is_reverse != right_read.is_reverse:
+        counter['Unexpected orientation'] += 1
     else:
         return True
     return False

--- a/variant_remapping_tools/tests/test_reads_to_remapped_variants.py
+++ b/variant_remapping_tools/tests/test_reads_to_remapped_variants.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 import pysam
 from unittest import TestCase
 from variant_remapping_tools.reads_to_remapped_variants import fetch_bases, process_bam_file, \
-    calculate_new_variant_definition
+    calculate_new_variant_definition, _order_reads
 
 
 class TestProcess(TestCase):
@@ -50,18 +50,46 @@ class TestProcess(TestCase):
         process_bam_file(bamfile, output_file, out_failed_file, fasta_path, True, 50, summary_file)
 
         expected = [
-            'chr2	48	.	C	A	50	PASS	.\n',
-            'chr2	48	.	C	T	50	PASS	.\n',
-            'chr2	98	.	C	CG	50	PASS	.\n',
-            'chr2	1078	.	A	G	50	PASS	.\n',
-            'chr2	1818	.	AAC	A	50	PASS	.\n',
-            'chr2	2030	.	A	TCC	50	PASS	.\n'
+            'chr2	48	.	C	A	50	PASS	st=+;rac=.\n',
+            'chr2	48	.	C	T	50	PASS	st=+;rac=.\n',
+            'chr2	98	.	C	CG	50	PASS	st=+;rac=.\n',
+            'chr2	1078	.	A	G	50	PASS	st=+;rac=G-A\n',
+            'chr2	1818	.	AAC	A	50	PASS	st=+;rac=.\n',
+            'chr2	2030	.	A	TCC	50	PASS	st=+;rac=.\n'
         ]
         with open(output_file, 'r') as vcf:
             for(i, line) in enumerate(vcf):
                 assert line == expected[i]
             # Expected and Generated VCF have the same number of lines
             assert i+1 == len(expected)
+
+    def test_order_reads(self):
+        primary_group = [
+            Mock(reference_name='chr2', reference_start=1, reference_end=47, is_reverse=False),
+            Mock(reference_name='chr2', reference_start=48, reference_end=58, is_reverse=False)
+        ]
+        primary_to_supplementary = {}
+        left_read, right_read = _order_reads(primary_group, primary_to_supplementary)
+        assert left_read == primary_group[0]
+        assert right_read == primary_group[1]
+
+        primary_group = [
+            Mock(reference_name='chr2', reference_start=48, reference_end=58, is_reverse=True),
+            Mock(reference_name='chr2', reference_start=1, reference_end=47, is_reverse=True)
+        ]
+        left_read, right_read = _order_reads(primary_group, primary_to_supplementary)
+        assert left_read == primary_group[1]
+        assert right_read == primary_group[0]
+
+        primary_group = [
+            Mock(reference_name='chr2', reference_start=1, reference_end=10, is_reverse=False),
+            Mock(reference_name='chr2', reference_start=48, reference_end=58, is_reverse=False)
+        ]
+        supplementary_read = Mock(reference_name='chr2', reference_start=20, reference_end=47, is_reverse=False)
+        primary_to_supplementary = {primary_group[0]: [supplementary_read]}
+        left_read, right_read = _order_reads(primary_group, primary_to_supplementary)
+        assert left_read == supplementary_read
+        assert right_read == primary_group[1]
 
     def test_calculate_new_variant_definition(self):
         fasta = 'fasta_path'
@@ -70,25 +98,25 @@ class TestProcess(TestCase):
         left_read = Mock(query_name='chr1|48|C|A', reference_name='chr2', reference_start=1, reference_end=47, is_reverse=False)
         right_read = Mock(query_name='chr1|48|C|A', reference_name='chr2', reference_start=48, reference_end=108, is_reverse=False)
         with patch('variant_remapping_tools.reads_to_remapped_variants.fetch_bases', return_value='C'):
-            assert calculate_new_variant_definition(left_read, right_read, fasta) == (48, 'C', ['A'])
+            assert calculate_new_variant_definition(left_read, right_read, fasta) == (48, 'C', ['A'], ['st=+', 'rac=.'])
 
         # Reverse strand alignment for SNP
         left_read = Mock(query_name='chr1|48|C|A,T', reference_name='chr2', reference_start=1, reference_end=47, is_reverse=True)
         right_read = Mock(query_name='chr1|48|C|A,T', reference_name='chr2', reference_start=48, reference_end=108, is_reverse=True)
         with patch('variant_remapping_tools.reads_to_remapped_variants.fetch_bases', return_value='G'):
-            assert calculate_new_variant_definition(left_read, right_read, fasta) == (48, 'G', ['T', 'A'])
+            assert calculate_new_variant_definition(left_read, right_read, fasta) == (48, 'G', ['T', 'A'], ['st=-', 'rac=.'])
 
         # Forward strand alignment for SNP with novel allele
         left_read = Mock(query_name='chr1|48|T|A', reference_name='chr2', reference_start=1, reference_end=47, is_reverse=False)
         right_read = Mock(query_name='chr1|48|T|A', reference_name='chr2', reference_start=48, reference_end=108, is_reverse=False)
         with patch('variant_remapping_tools.reads_to_remapped_variants.fetch_bases', return_value='C'):
-            assert calculate_new_variant_definition(left_read, right_read, fasta) == (48, 'C', ['A', 'T'])
+            assert calculate_new_variant_definition(left_read, right_read, fasta) == (48, 'C', ['A', 'T'], ['st=+', 'rac=T-C', 'nra=T'])
 
         # Forward strand alignment for Deletion
         left_read = Mock(query_name='chr1|48|CAA|C', reference_name='chr2', reference_start=1, reference_end=47, is_reverse=False)
         right_read = Mock(query_name='chr1|48|CAA|C', reference_name='chr2', reference_start=50, reference_end=110, is_reverse=False)
         with patch('variant_remapping_tools.reads_to_remapped_variants.fetch_bases', return_value='CAA'):
-            assert calculate_new_variant_definition(left_read, right_read, fasta) == (48, 'CAA', ['C'])
+            assert calculate_new_variant_definition(left_read, right_read, fasta) == (48, 'CAA', ['C'], ['st=+', 'rac=.'])
 
         # Reverse strand alignment for a deletion
         # REF  AAAAAAAAAAAAAAAAATTGCCCCCCCCCCCCCCCCC
@@ -98,7 +126,7 @@ class TestProcess(TestCase):
         left_read = Mock(query_name='chr1|48|CAA|C', reference_name='chr2', reference_start=1, reference_end=47, is_reverse=True)
         right_read = Mock(query_name='chr1|48|CAA|C', reference_name='chr2', reference_start=50, reference_end=110, is_reverse=True)
         with patch('variant_remapping_tools.reads_to_remapped_variants.fetch_bases', return_value='TTG'):
-            assert calculate_new_variant_definition(left_read, right_read, fasta) == (48, 'TTG', ['G'])
+            assert calculate_new_variant_definition(left_read, right_read, fasta) == (48, 'TTG', ['G'], ['st=-', 'rac=.'])
 
 
     @staticmethod

--- a/variant_remapping_tools/tests/test_reads_to_remapped_variants.py
+++ b/variant_remapping_tools/tests/test_reads_to_remapped_variants.py
@@ -46,7 +46,7 @@ class TestProcess(TestCase):
         fasta_path = self.get_test_resource('new_genome.fa')
         output_file = '/tmp/remapped.vcf'
         out_failed_file = '/tmp/unmapped.vcf'
-        process_bam_file(bamfile, output_file, out_failed_file, fasta_path, True, 0)
+        process_bam_file(bamfile, output_file, out_failed_file, fasta_path, True)
 
         expected = [
             'chr2	48	.	C	A	50	PASS	.\n',
@@ -66,26 +66,26 @@ class TestProcess(TestCase):
         fasta = 'fasta_path'
 
         # Forward strand alignment for SNP
-        left_read = Mock(query_name='chr1|48|C|A', reference_name='chr2', pos=1, reference_end=47, is_reverse=False)
-        right_read = Mock(query_name='chr1|48|C|A', reference_name='chr2', pos=48, reference_end=108, is_reverse=False)
+        left_read = Mock(query_name='chr1|48|C|A', reference_name='chr2', reference_start=1, reference_end=47, is_reverse=False)
+        right_read = Mock(query_name='chr1|48|C|A', reference_name='chr2', reference_start=48, reference_end=108, is_reverse=False)
         with patch('variant_remapping_tools.reads_to_remapped_variants.fetch_bases', return_value='C'):
             assert calculate_new_variant_definition(left_read, right_read, fasta) == (48, 'C', ['A'])
 
         # Reverse strand alignment for SNP
-        left_read = Mock(query_name='chr1|48|C|A,T', reference_name='chr2', pos=1, reference_end=47, is_reverse=True)
-        right_read = Mock(query_name='chr1|48|C|A,T', reference_name='chr2', pos=48, reference_end=108, is_reverse=True)
+        left_read = Mock(query_name='chr1|48|C|A,T', reference_name='chr2', reference_start=1, reference_end=47, is_reverse=True)
+        right_read = Mock(query_name='chr1|48|C|A,T', reference_name='chr2', reference_start=48, reference_end=108, is_reverse=True)
         with patch('variant_remapping_tools.reads_to_remapped_variants.fetch_bases', return_value='G'):
             assert calculate_new_variant_definition(left_read, right_read, fasta) == (48, 'G', ['T', 'A'])
 
         # Forward strand alignment for SNP with novel allele
-        left_read = Mock(query_name='chr1|48|T|A', reference_name='chr2', pos=1, reference_end=47, is_reverse=False)
-        right_read = Mock(query_name='chr1|48|T|A', reference_name='chr2', pos=48, reference_end=108, is_reverse=False)
+        left_read = Mock(query_name='chr1|48|T|A', reference_name='chr2', reference_start=1, reference_end=47, is_reverse=False)
+        right_read = Mock(query_name='chr1|48|T|A', reference_name='chr2', reference_start=48, reference_end=108, is_reverse=False)
         with patch('variant_remapping_tools.reads_to_remapped_variants.fetch_bases', return_value='C'):
             assert calculate_new_variant_definition(left_read, right_read, fasta) == (48, 'C', ['A', 'T'])
 
         # Forward strand alignment for Deletion
-        left_read = Mock(query_name='chr1|48|CAA|C', reference_name='chr2', pos=1, reference_end=47, is_reverse=False)
-        right_read = Mock(query_name='chr1|48|CAA|C', reference_name='chr2', pos=50, reference_end=110, is_reverse=False)
+        left_read = Mock(query_name='chr1|48|CAA|C', reference_name='chr2', reference_start=1, reference_end=47, is_reverse=False)
+        right_read = Mock(query_name='chr1|48|CAA|C', reference_name='chr2', reference_start=50, reference_end=110, is_reverse=False)
         with patch('variant_remapping_tools.reads_to_remapped_variants.fetch_bases', return_value='CAA'):
             assert calculate_new_variant_definition(left_read, right_read, fasta) == (48, 'CAA', ['C'])
 
@@ -94,8 +94,8 @@ class TestProcess(TestCase):
         #            read 2             read 1
         #      <----------------TTG<----------------
         #                       G
-        left_read = Mock(query_name='chr1|48|CAA|C', reference_name='chr2', pos=1, reference_end=47, is_reverse=True)
-        right_read = Mock(query_name='chr1|48|CAA|C', reference_name='chr2', pos=50, reference_end=110, is_reverse=True)
+        left_read = Mock(query_name='chr1|48|CAA|C', reference_name='chr2', reference_start=1, reference_end=47, is_reverse=True)
+        right_read = Mock(query_name='chr1|48|CAA|C', reference_name='chr2', reference_start=50, reference_end=110, is_reverse=True)
         with patch('variant_remapping_tools.reads_to_remapped_variants.fetch_bases', return_value='TTG'):
             assert calculate_new_variant_definition(left_read, right_read, fasta) == (48, 'TTG', ['G'])
 

--- a/variant_remapping_tools/tests/test_reads_to_remapped_variants.py
+++ b/variant_remapping_tools/tests/test_reads_to_remapped_variants.py
@@ -45,8 +45,9 @@ class TestProcess(TestCase):
         bamfile = self.get_test_resource("reads_aligned_test.bam")
         fasta_path = self.get_test_resource('new_genome.fa')
         output_file = '/tmp/remapped.vcf'
+        summary_file = '/tmp/summary.yml'
         out_failed_file = '/tmp/unmapped.vcf'
-        process_bam_file(bamfile, output_file, out_failed_file, fasta_path, True)
+        process_bam_file(bamfile, output_file, out_failed_file, fasta_path, True, 50, summary_file)
 
         expected = [
             'chr2	48	.	C	A	50	PASS	.\n',

--- a/variant_to_realignment.nf
+++ b/variant_to_realignment.nf
@@ -352,7 +352,7 @@ workflow process_split_reads_long {
             new_genome_fa, flank_length
         )
         sortByName(alignWithMinimap.out.reads_aligned_bam)
-        // This last step will use all alignments enven the one that have alternative secondary alignments
+        // This last step will use all alignments even the ones that have alternative secondary alignments
         readsToRemappedVariants(sortByName.out.reads_aligned_sorted_bam, new_genome_fa, flank_length, false)
 
     emit:

--- a/variant_to_realignment.nf
+++ b/variant_to_realignment.nf
@@ -173,7 +173,22 @@ process alignWithMinimap {
                  --secondary=yes -N 2 \
                  -a genome.fa variant_read1.fa variant_read2.fa | samtools view -bS - > reads_aligned.bam
         """
+}
 
+/*
+ * Sort BAM file by name
+ */
+process sortByName {
+
+    input:
+        path "reads_aligned.bam"
+
+    output:
+        path "reads_aligned_name_sorted.bam", emit: reads_aligned_sorted_bam
+
+    """
+    samtools sort -n -O BAM -o reads_aligned_name_sorted.bam reads_aligned.bam
+    """
 }
 
 /*
@@ -252,7 +267,8 @@ workflow process_split_reads {
             new_genome_fa,
             flank_length
         )
-        readsToRemappedVariants(alignWithMinimap.out.reads_aligned_bam, new_genome_fa, flank_length)
+        sortByName(alignWithMinimap.out.reads_aligned_bam)
+        readsToRemappedVariants(sortByName.out.reads_aligned_sorted_bam, new_genome_fa, flank_length)
 
     emit:
         variants_remapped = readsToRemappedVariants.out.variants_remapped
@@ -287,8 +303,8 @@ workflow process_split_reads_mid {
             extractVariantInfoToFastaHeader.out.variant_read2_with_info,
             new_genome_fa, flank_length
         )
-        readsToRemappedVariants(alignWithMinimap.out.reads_aligned_bam, new_genome_fa, flank_length)
-
+        sortByName(alignWithMinimap.out.reads_aligned_bam)
+        readsToRemappedVariants(sortByName.out.reads_aligned_sorted_bam, new_genome_fa, flank_length)
     emit:
         variants_remapped = readsToRemappedVariants.out.variants_remapped
         variants_unmapped = readsToRemappedVariants.out.variants_unmapped
@@ -322,7 +338,8 @@ workflow process_split_reads_long {
             extractVariantInfoToFastaHeader.out.variant_read2_with_info,
             new_genome_fa, flank_length
         )
-        readsToRemappedVariants(alignWithMinimap.out.reads_aligned_bam, new_genome_fa, flank_length)
+        sortByName(alignWithMinimap.out.reads_aligned_bam)
+        readsToRemappedVariants(sortByName.out.reads_aligned_sorted_bam, new_genome_fa, flank_length)
 
     emit:
         variants_remapped = readsToRemappedVariants.out.variants_remapped

--- a/variant_to_realignment.nf
+++ b/variant_to_realignment.nf
@@ -164,7 +164,7 @@ process alignWithMinimap {
         # Options used by the 'sr' preset with some modifications:
         # -O6,16 instead of -O12,32 --> reduce indel cost
         # -B5 instead of -B10 --> reduce mismatch cost
-        # --end-bonus 20  --> bonus score when the end of the read aligns to mimic global alignment.
+        # --end-bonus 20 --> bonus score when the end of the read aligns to mimic global alignment.
         # --secondary=yes -N 2 --> allow up to 2 secondary alignments
         minimap2 -k21 -w11 --sr --frag=yes -A2 -B5 -O6,16 --end-bonus 20 -E2,1 -r50 -p.5 -z 800,200\
                  -f1000,5000 -n2 -m20 -s40 -g200 -2K50m --heap-sort=yes --secondary=yes -N 2 \

--- a/variant_to_realignment.nf
+++ b/variant_to_realignment.nf
@@ -236,20 +236,20 @@ process readsToRemappedVariants {
         path "summary.yml", emit: summary_yml
 
     script:
-    if (filter_align_with_secondary)
-    """
-    # Ensure that we will use the reads_to_remapped_variants.py from this repo
-    ${baseDir}/variant_remapping_tools/reads_to_remapped_variants.py -i reads_aligned.bam \
-        -o variants_remapped.vcf  --newgenome genome.fa --out_failed_file variants_unmapped.vcf \
-        --flank_length $flank_length --summary summary.yml --filter_align_with_secondary
-    """
-    else
-    """
-    # Ensure that we will use the reads_to_remapped_variants.py from this repo
-    ${baseDir}/variant_remapping_tools/reads_to_remapped_variants.py -i reads_aligned.bam \
-        -o variants_remapped.vcf  --newgenome genome.fa --out_failed_file variants_unmapped.vcf \
-        --flank_length $flank_length --summary summary.yml
-    """
+        if (filter_align_with_secondary)
+            """
+            # Ensure that we will use the reads_to_remapped_variants.py from this repo
+            ${baseDir}/variant_remapping_tools/reads_to_remapped_variants.py -i reads_aligned.bam \
+                -o variants_remapped.vcf  --newgenome genome.fa --out_failed_file variants_unmapped.vcf \
+                --flank_length $flank_length --summary summary.yml --filter_align_with_secondary
+            """
+        else
+            """
+            # Ensure that we will use the reads_to_remapped_variants.py from this repo
+            ${baseDir}/variant_remapping_tools/reads_to_remapped_variants.py -i reads_aligned.bam \
+                -o variants_remapped.vcf  --newgenome genome.fa --out_failed_file variants_unmapped.vcf \
+                --flank_length $flank_length --summary summary.yml
+           """
 
 }
 

--- a/variant_to_realignment.nf
+++ b/variant_to_realignment.nf
@@ -9,7 +9,7 @@ nextflow.enable.dsl=2
 /*
  * Convert the VCF file to BED format.
  */
-process ConvertVCFToBed {
+process convertVCFToBed {
 
     input:
         path "source.vcf"
@@ -251,8 +251,8 @@ workflow process_split_reads {
 
     main:
         flank_length = 50
-        ConvertVCFToBed(source_vcf)
-        flankingRegionBed(ConvertVCFToBed.out.variants_bed, old_genome_chrom_sizes, flank_length)
+        convertVCFToBed(source_vcf)
+        flankingRegionBed(convertVCFToBed.out.variants_bed, old_genome_chrom_sizes, flank_length)
         flankingRegionFasta(
             flankingRegionBed.out.flanking_r1_bed, flankingRegionBed.out.flanking_r2_bed,
             old_genome_fa, old_genome_fa_fai
@@ -288,8 +288,8 @@ workflow process_split_reads_mid {
 
     main:
         flank_length = 2000
-        ConvertVCFToBed(source_vcf)
-        flankingRegionBed(ConvertVCFToBed.out.variants_bed, old_genome_chrom_sizes, flank_length)
+        convertVCFToBed(source_vcf)
+        flankingRegionBed(convertVCFToBed.out.variants_bed, old_genome_chrom_sizes, flank_length)
         flankingRegionFasta(
             flankingRegionBed.out.flanking_r1_bed, flankingRegionBed.out.flanking_r2_bed,
             old_genome_fa, old_genome_fa_fai
@@ -323,8 +323,8 @@ workflow process_split_reads_long {
 
     main:
         flank_length = 50000
-        ConvertVCFToBed(source_vcf)
-        flankingRegionBed(ConvertVCFToBed.out.variants_bed, old_genome_chrom_sizes, flank_length)
+        convertVCFToBed(source_vcf)
+        flankingRegionBed(convertVCFToBed.out.variants_bed, old_genome_chrom_sizes, flank_length)
         flankingRegionFasta(
             flankingRegionBed.out.flanking_r1_bed, flankingRegionBed.out.flanking_r2_bed,
             old_genome_fa, old_genome_fa_fai
@@ -359,8 +359,8 @@ workflow process_split_reads_with_bowtie {
 
     main:
         flank_length = 50
-        ConvertVCFToBed(source_vcf)
-        flankingRegionBed(ConvertVCFToBed.out.variants_bed, old_genome_chrom_sizes, flank_length)
+        convertVCFToBed(source_vcf)
+        flankingRegionBed(convertVCFToBed.out.variants_bed, old_genome_chrom_sizes, flank_length)
         flankingRegionFasta(
             flankingRegionBed.out.flanking_r1_bed, flankingRegionBed.out.flanking_r2_bed,
             old_genome_fa, old_genome_fa_fai

--- a/variant_to_realignment.nf
+++ b/variant_to_realignment.nf
@@ -100,7 +100,7 @@ process extractVariantInfoToFastaHeader {
     // Disable the string interpolation using single quotes
     // https://www.nextflow.io/docs/latest/script.html#string-interpolation
     '''
-    # Store variant positions (Add + 1 to revert to one based position)
+    # Store variant positions (add + 1 to revert to one based position)
     awk '{print $1"\t"$3 + 1}' flanking_r1.bed > position.txt
 
     # Store ref bases


### PR DESCRIPTION
This PR bring in two new round of alignment using Minimap2. The first round uses 50 bases paired end reads, the second 2000 bases and the last uses 50Kb.
This also adds a Yaml file that reports the number of variants that are successfully remapped.
