### PR TITLE
EVA-2380 - Reduce FP

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -108,7 +108,7 @@ process buildHeader {
     # Add variant remapping INFO definition to the header
     echo -e '##INFO=<ID=st,Number=1,Type=String,Description="Strand change observed in the alignment.">' >> temp_header.txt
     echo -e '##INFO=<ID=rac,Number=1,Type=String,Description="Reference allele change during the alignment.">' >> temp_header.txt
-    echo -e '##INFO=<ID=nra,Number=1,Type=String,Description="Novel reference allele that was not observed in the previous set of alternate">' >> temp_header.txt
+    echo -e '##INFO=<ID=nra,Number=0,Type=Flag,Description="Novel reference allele that was not observed in the previous set of alternate">' >> temp_header.txt
     echo -e '##INFO=<ID=zlr,Number=1,Type=String,Description="Zero length allele. Hard to be expanded from the reference.">' >> temp_header.txt
     # Add the two headers together and add the column names
     cat temp_header.txt contigs.txt > final_header.txt

--- a/main.nf
+++ b/main.nf
@@ -109,7 +109,7 @@ process buildHeader {
     echo -e '##INFO=<ID=st,Number=1,Type=String,Description="Strand change observed in the alignment.">' >> temp_header.txt
     echo -e '##INFO=<ID=rac,Number=1,Type=String,Description="Reference allele change during the alignment.">' >> temp_header.txt
     echo -e '##INFO=<ID=nra,Number=0,Type=Flag,Description="Novel reference allele that was not observed in the previous set of alternate">' >> temp_header.txt
-    echo -e '##INFO=<ID=zlr,Number=1,Type=String,Description="Zero length allele. Hard to be expanded from the reference.">' >> temp_header.txt
+    echo -e '##INFO=<ID=zlr,Number=0,Type=Flag,Description="Zero length allele. Had to be expanded from the reference.">' >> temp_header.txt
     # Add the two headers together and add the column names
     cat temp_header.txt contigs.txt > final_header.txt
     echo -e "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO" >> final_header.txt

--- a/tests/test_pipeline.sh
+++ b/tests/test_pipeline.sh
@@ -31,13 +31,13 @@ ls ${SCRIPT_DIR}/resources/remap.vcf \
 # Build the expected VCF
 cat << EOT > "${SCRIPT_DIR}/resources/expected_remap.vcf"
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
-chr2	48	.	C	A	50	PASS	st=+;rac=.
-chr2	48	.	C	T	50	PASS	st=+;rac=.
-chr2	98	.	C	CG	50	PASS	st=+;rac=.
+chr2	48	.	C	A	50	PASS	st=+
+chr2	48	.	C	T	50	PASS	st=+
+chr2	98	.	C	CG	50	PASS	st=+
 chr2	1078	.	A	G	50	PASS	st=+;rac=G-A
-chr2	1818	.	AAC	A	50	PASS	st=+;rac=.
-chr2	2030	.	A	TCC	50	PASS	st=+;rac=.
-chr2	3510	.	T	C	50	PASS	st=+;rac=.
+chr2	1818	.	AAC	A	50	PASS	st=+
+chr2	2030	.	A	TCC	50	PASS	st=+
+chr2	3510	.	T	C	50	PASS	st=+
 EOT
 
 # Compare vs the expected VCF

--- a/variant_remapping_tools/reads_to_remapped_variants.py
+++ b/variant_remapping_tools/reads_to_remapped_variants.py
@@ -176,7 +176,7 @@ def pass_aligned_filtering(left_read, right_read, counter):
     """
     # in CIGAR tuples the operation is coded as an integer
     # https://pysam.readthedocs.io/en/latest/api.html#pysam.AlignedSegment.cigartuples
-    if left_read.cigartuples[-1][0] == 4 or right_read.cigartuples[0][0] == 4:
+    if left_read.cigartuples[-1][0] == pysam.CSOFT_CLIP or right_read.cigartuples[0][0] == pysam.CSOFT_CLIP:
         counter['Soft-clipped alignments'] += 1
     elif left_read.reference_end > right_read.reference_start:
         counter['Overlapping alignment'] += 1
@@ -227,7 +227,8 @@ def process_bam_file(bam_file_path, output_file, out_failed_file, new_genome, fi
             if pass_basic_filtering(primary_group, secondary_group, primary_to_supplementary, counter, filter_align_with_secondary):
                 left_read, right_read = _order_reads(primary_group, primary_to_supplementary)
                 if pass_aligned_filtering(left_read, right_read, counter):
-                    varpos, new_ref, new_alts, ops, low_confidence = calculate_new_variant_definition(left_read, right_read, fasta)
+                    varpos, new_ref, new_alts, ops, low_confidence = \
+                        calculate_new_variant_definition(left_read, right_read, fasta)
                     if not low_confidence:
                         counter['Remapped'] += 1
                         info = left_read.query_name.split('|')

--- a/variant_remapping_tools/tests/test_reads_to_remapped_variants.py
+++ b/variant_remapping_tools/tests/test_reads_to_remapped_variants.py
@@ -60,12 +60,12 @@ class TestProcess(TestCase):
         process_bam_file(bamfile, output_file, out_failed_file, fasta_path, True, 50, summary_file)
 
         expected = [
-            'chr2	48	.	C	A	50	PASS	st=+;rac=.\n',
-            'chr2	48	.	C	T	50	PASS	st=+;rac=.\n',
-            'chr2	98	.	C	CG	50	PASS	st=+;rac=.\n',
+            'chr2	48	.	C	A	50	PASS	st=+\n',
+            'chr2	48	.	C	T	50	PASS	st=+\n',
+            'chr2	98	.	C	CG	50	PASS	st=+\n',
             'chr2	1078	.	A	G	50	PASS	st=+;rac=G-A\n',
-            'chr2	1818	.	AAC	A	50	PASS	st=+;rac=.\n',
-            'chr2	2030	.	A	TCC	50	PASS	st=+;rac=.\n'
+            'chr2	1818	.	AAC	A	50	PASS	st=+\n',
+            'chr2	2030	.	A	TCC	50	PASS	st=+\n'
         ]
         with open(output_file, 'r') as vcf:
             for(i, line) in enumerate(vcf):
@@ -125,25 +125,25 @@ class TestProcess(TestCase):
         left_read = self.mk_read(query_name='chr1|48|C|A', reference_name='chr2', reference_start=1, reference_end=47, is_reverse=False)
         right_read = self.mk_read(query_name='chr1|48|C|A', reference_name='chr2', reference_start=48, reference_end=108, is_reverse=False)
         with patch('variant_remapping_tools.reads_to_remapped_variants.fetch_bases', return_value='C'):
-            assert calculate_new_variant_definition(left_read, right_read, fasta) == (48, 'C', ['A'], ['st=+', 'rac=.'])
+            assert calculate_new_variant_definition(left_read, right_read, fasta) == (48, 'C', ['A'], ['st=+'], False)
 
         # Reverse strand alignment for SNP
         left_read = self.mk_read(query_name='chr1|48|C|A,T', reference_name='chr2', reference_start=1, reference_end=47, is_reverse=True)
         right_read = self.mk_read(query_name='chr1|48|C|A,T', reference_name='chr2', reference_start=48, reference_end=108, is_reverse=True)
         with patch('variant_remapping_tools.reads_to_remapped_variants.fetch_bases', return_value='G'):
-            assert calculate_new_variant_definition(left_read, right_read, fasta) == (48, 'G', ['T', 'A'], ['st=-', 'rac=.'])
+            assert calculate_new_variant_definition(left_read, right_read, fasta) == (48, 'G', ['T', 'A'], ['st=-'], False)
 
         # Forward strand alignment for SNP with novel allele
         left_read = self.mk_read(query_name='chr1|48|T|A', reference_name='chr2', reference_start=1, reference_end=47, is_reverse=False)
         right_read = self.mk_read(query_name='chr1|48|T|A', reference_name='chr2', reference_start=48, reference_end=108, is_reverse=False)
         with patch('variant_remapping_tools.reads_to_remapped_variants.fetch_bases', return_value='C'):
-            assert calculate_new_variant_definition(left_read, right_read, fasta) == (48, 'C', ['A', 'T'], ['st=+', 'rac=T-C', 'nra=T'])
+            assert calculate_new_variant_definition(left_read, right_read, fasta) == (48, 'C', ['A', 'T'], ['st=+', 'rac=T-C', 'nra'], True)
 
         # Forward strand alignment for Deletion
         left_read = self.mk_read(query_name='chr1|48|CAA|C', reference_name='chr2', reference_start=1, reference_end=47, is_reverse=False)
         right_read = self.mk_read(query_name='chr1|48|CAA|C', reference_name='chr2', reference_start=50, reference_end=110, is_reverse=False)
         with patch('variant_remapping_tools.reads_to_remapped_variants.fetch_bases', return_value='CAA'):
-            assert calculate_new_variant_definition(left_read, right_read, fasta) == (48, 'CAA', ['C'], ['st=+', 'rac=.'])
+            assert calculate_new_variant_definition(left_read, right_read, fasta) == (48, 'CAA', ['C'], ['st=+'], False)
 
         # Reverse strand alignment for a deletion
         # REF  AAAAAAAAAAAAAAAAATTGCCCCCCCCCCCCCCCCC
@@ -153,7 +153,7 @@ class TestProcess(TestCase):
         left_read = self.mk_read(query_name='chr1|48|CAA|C', reference_name='chr2', reference_start=1, reference_end=47, is_reverse=True)
         right_read = self.mk_read(query_name='chr1|48|CAA|C', reference_name='chr2', reference_start=50, reference_end=110, is_reverse=True)
         with patch('variant_remapping_tools.reads_to_remapped_variants.fetch_bases', return_value='TTG'):
-            assert calculate_new_variant_definition(left_read, right_read, fasta) == (48, 'TTG', ['G'], ['st=-', 'rac=.'])
+            assert calculate_new_variant_definition(left_read, right_read, fasta) == (48, 'TTG', ['G'], ['st=-'], False)
 
 
     @staticmethod

--- a/variant_remapping_tools/tests/test_reads_to_remapped_variants.py
+++ b/variant_remapping_tools/tests/test_reads_to_remapped_variants.py
@@ -1,10 +1,11 @@
 import os
+from collections import Counter
 from unittest.mock import Mock, patch
 
 import pysam
 from unittest import TestCase
 from variant_remapping_tools.reads_to_remapped_variants import fetch_bases, process_bam_file, \
-    calculate_new_variant_definition, _order_reads, link_supplementary
+    calculate_new_variant_definition, _order_reads, link_supplementary, pass_aligned_filtering, group_reads
 
 
 class TestProcess(TestCase):
@@ -71,6 +72,13 @@ class TestProcess(TestCase):
                 assert line == expected[i]
             # Expected and Generated VCF have the same number of lines
             assert i+1 == len(expected)
+
+    def test_pass_aligned_filtering(self):
+        left_read = self.mk_read(reference_start=0, reference_end=47, cigartuples=[(0, 47)])
+        right_read = self.mk_read(reference_start=51, reference_end=95,  cigartuples=[(4, 3), (0, 44)])
+        counter = Counter()
+        assert not pass_aligned_filtering(left_read, right_read, counter)
+        assert counter['Soft-clipped alignments'] == 1
 
     def test_link_supplementary(self):
         primary_group = [


### PR DESCRIPTION
This PR reduces the number of False positive by removing the variants that are remapped with significant changes. 
In testing, we saw that these groups are enriched in False positives and thus are more likely to be errors.

It also fixes a bug in the way the Soft clipping was detected 