### PR TITLE
Allow the read to remap step to be run in parallel and only merge after

### DIFF
--- a/variant_remapping_tools/merge_yaml.py
+++ b/variant_remapping_tools/merge_yaml.py
@@ -1,0 +1,43 @@
+#! /usr/bin/env python3
+import argparse
+
+import yaml
+
+
+def merge_two_dict(d1, d2):
+    result = {}
+    for key in set(d1) | set(d2):
+        if isinstance(d1.get(key), dict) or isinstance(d2.get(key), dict):
+            result[key] = merge_two_dict(d1.get(key, dict()), d2.get(key, dict()))
+        else:
+            result[key] = d1.get(key, 0) + d2.get(key, 0)
+    return result
+
+
+def merge_yaml_files(input_yamls, output_yaml):
+    output = {}
+    for input_yaml in input_yamls:
+        with open(input_yaml) as open_input:
+            data = yaml.safe_load(open_input) or {}
+            output = merge_two_dict(output, data)
+
+    with open(output_yaml, 'w') as open_output:
+        yaml.safe_dump(output, open_output)
+
+
+def main():
+    description = ('Merge multiple yaml file containing stats by summing the overlapping fields')
+
+    parser = argparse.ArgumentParser(description=description)
+
+    parser.add_argument('--inputs', type=str, required=True, nargs='+',
+                        help='YAML files containing the input summary metrics')
+    parser.add_argument('--output', type=str, required=True,
+                        help='YAML files containing the output summary metrics')
+    args = parser.parse_args()
+
+    merge_yaml_files(args.inputs, args.output)
+
+
+if __name__ == '__main__':
+    main()

--- a/variant_remapping_tools/reads_to_remapped_variants.py
+++ b/variant_remapping_tools/reads_to_remapped_variants.py
@@ -1,6 +1,5 @@
 #! /usr/bin/env python3
 import argparse
-import time
 from argparse import RawTextHelpFormatter
 from collections import Counter, defaultdict
 

--- a/variant_remapping_tools/reads_to_remapped_variants.py
+++ b/variant_remapping_tools/reads_to_remapped_variants.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python3
 import argparse
+import time
 from argparse import RawTextHelpFormatter
 from collections import Counter, defaultdict
 

--- a/variant_to_realignment.nf
+++ b/variant_to_realignment.nf
@@ -272,7 +272,7 @@ process readsToRemappedVariants {
 }
 
 /*
- * Take the reads and process them to get the remapped variants
+ * Gather step for remapped and unmapped variants and the summary yaml file
  *
  */
 process merge_variants {

--- a/variant_to_realignment.nf
+++ b/variant_to_realignment.nf
@@ -240,12 +240,11 @@ process alignWithBowtie {
 
 /*
  * Take the reads and process them to get the remapped variants
- *
  */
 process readsToRemappedVariants {
 
     input:
-        path "reads*.bam"
+        path "reads.bam"
         path "genome.fa"
         val flank_length
         val filter_align_with_secondary
@@ -259,7 +258,7 @@ process readsToRemappedVariants {
         if (filter_align_with_secondary)
             """
             # Ensure that we will use the reads_to_remapped_variants.py from this repo
-            ${baseDir}/variant_remapping_tools/reads_to_remapped_variants.py -i reads*.bam \
+            ${baseDir}/variant_remapping_tools/reads_to_remapped_variants.py -i reads.bam \
                 -o variants_remapped.vcf  --newgenome genome.fa --out_failed_file variants_unmapped.vcf \
                 --flank_length $flank_length --summary summary.yml --filter_align_with_secondary
             """
@@ -270,8 +269,31 @@ process readsToRemappedVariants {
                 -o variants_remapped.vcf  --newgenome genome.fa --out_failed_file variants_unmapped.vcf \
                 --flank_length $flank_length --summary summary.yml
            """
+}
+
+/*
+ * Take the reads and process them to get the remapped variants
+ *
+ */
+process merge_variants {
+    input:
+        path "remapped*.vcf"
+        path "unmapped*.vcf"
+        path "summary*.yml"
+
+    output:
+       path "variants_remapped.vcf", emit: variants_remapped
+       path "variants_unmapped.vcf", emit: variants_unmapped
+       path "output_summary.yml", emit: summary_yml
+
+    """
+    cat remapped*.vcf > variants_remapped.vcf
+    cat unmapped*.vcf > variants_unmapped.vcf
+    ${baseDir}/variant_remapping_tools/merge_yaml.py --input summary*.yml --output output_summary.yml
+    """
 
 }
+
 
 workflow process_split_reads_generic {
     take:
@@ -311,14 +333,19 @@ workflow process_split_reads_generic {
         sortByName(alignWithMinimap.out.reads_aligned_bam)
         // Collect all the bam files in the next step
         readsToRemappedVariants(
-            sortByName.out.reads_aligned_sorted_bam.collect(), new_genome_fa,
+            sortByName.out.reads_aligned_sorted_bam, new_genome_fa,
             flank_length, filter_align_with_secondary
+        )
+        merge_variants(
+            readsToRemappedVariants.out.variants_remapped.collect(),
+            readsToRemappedVariants.out.variants_unmapped.collect(),
+            readsToRemappedVariants.out.summary_yml.collect()
         )
 
     emit:
-        variants_remapped = readsToRemappedVariants.out.variants_remapped
-        variants_unmapped = readsToRemappedVariants.out.variants_unmapped
-        summary_yml = readsToRemappedVariants.out.summary_yml
+        variants_remapped = merge_variants.out.variants_remapped
+        variants_unmapped = merge_variants.out.variants_unmapped
+        summary_yml = merge_variants.out.summary_yml
 }
 
 workflow process_split_reads {
@@ -332,7 +359,7 @@ workflow process_split_reads {
     main:
         flank_length = 50
         filter_align_with_secondary = true
-        chunk_size = 5000000
+        chunk_size = 2
         process_split_reads_generic(
             source_vcf, old_genome_fa, old_genome_fa_fai, old_genome_chrom_sizes,
             new_genome_fa, new_genome_fa_fai, flank_length, filter_align_with_secondary,


### PR DESCRIPTION
When using scatter gather, only gather after the `readsToRemappedVariants` step