### PR TITLE
Remove variant that have non ATGC bases in the reference

### DIFF
--- a/conda.yml
+++ b/conda.yml
@@ -5,7 +5,6 @@ channels:
   - bioconda
 dependencies:
   - bedtools=2.29.2
-  - bowtie2=2.4.1
   - minimap2=2.17
   - samtools=1.9
   - bcftools=1.9

--- a/conda.yml
+++ b/conda.yml
@@ -4,9 +4,8 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bedtools=2.29.2
-  - minimap2=2.17
-  - samtools=1.9
-  - bcftools=1.9
-  - bedops=2.4.39
-  - tabix=0.2.6
+  - bedtools
+  - minimap2
+  - samtools
+  - bcftools
+  - tabix

--- a/variant_remapping_tools/reads_to_remapped_variants.py
+++ b/variant_remapping_tools/reads_to_remapped_variants.py
@@ -29,7 +29,7 @@ def calculate_new_variant_definition(left_read, right_read, ref_fasta, original_
                           right_read.reference_start - left_read.reference_end).upper()
 
     if len(set(new_ref).difference(nucleotide_alphabet)) != 0 :
-        failure_reason = 'Reference Allele not in non ACGT'
+        failure_reason = 'Reference Allele not in ACGT'
 
     new_pos = left_read.reference_end + 1
 

--- a/variant_remapping_tools/reads_to_remapped_variants.py
+++ b/variant_remapping_tools/reads_to_remapped_variants.py
@@ -8,6 +8,7 @@ from Bio.Seq import Seq
 from Bio.Alphabet import generic_dna
 import pysam
 
+nucleotide_alphabet = {'A', 'T', 'C', 'G'}
 
 def reverse_complement(sequence):
     return str(Seq(sequence, generic_dna).reverse_complement())
@@ -26,6 +27,9 @@ def calculate_new_variant_definition(left_read, right_read, ref_fasta, original_
     # Define new ref and new pos
     new_ref = fetch_bases(ref_fasta, left_read.reference_name, left_read.reference_end + 1,
                           right_read.reference_start - left_read.reference_end).upper()
+
+    if len(set(new_ref).difference(nucleotide_alphabet)) != 0 :
+        failure_reason = 'Reference Allele not in non ACGT'
 
     new_pos = left_read.reference_end + 1
 


### PR DESCRIPTION
I've encountered a case of a variant that remapped perfectly on a non ATCG base which fails at the normalisation stage. 
It does not make sense to remap a C->G variant onto an S (which mean C or G) so I'd rather fail these case.